### PR TITLE
Added a simple example for the set path

### DIFF
--- a/worlds/sims4/docs/setup_en.md
+++ b/worlds/sims4/docs/setup_en.md
@@ -24,7 +24,8 @@
 - By default, this mod only uses skills from the base game as checks and locations. You can optionally enable your packs in the YAML file if you would like to have them included in the randomization. Packs are unlikely to cause problems with the mod, however you can disable them optionally **NOT USING THE IN GAME PACK SELECTOR**.
   * If you don't know how disable packs without using the in game pack selector, you can use this [tutorial](https://jamesturner.yt/disablepacks) by James Turner.
 - Open the Archipelago Launcher and run the client. It should be called `The Sims 4 Client`. Upon the first time opening the client, it will prompt you to select your Mods folder. <strong>ONLY SELECT THE MODS FOLDER LOCATED AT</strong> <code>(your sims folder, typically called The Sims 4)/Mods</code>.
-  * If you have to manually se the path make sure you dont include quotes in the path
+  * If you have to manually set the path make sure you dont include quotes in the path
+  * Example: <code>/set_path C:/Users/User/Documents/Electronic Arts/The Sims 4/Mods</code>
 - Once you have selected the Mods folder if you've been prompted for it, follow the next steps before connecting.
 - Launch your copy of The Sims 4, and ensure you have Script Mods enabled. The mod will not work correctly if Script Mods are not enabled.
   * You can enable Script Mods by going to `Game Options -> Other -> Script Mods Allowed`.

--- a/worlds/sims4/docs/setup_en.md
+++ b/worlds/sims4/docs/setup_en.md
@@ -24,6 +24,7 @@
 - By default, this mod only uses skills from the base game as checks and locations. You can optionally enable your packs in the YAML file if you would like to have them included in the randomization. Packs are unlikely to cause problems with the mod, however you can disable them optionally **NOT USING THE IN GAME PACK SELECTOR**.
   * If you don't know how disable packs without using the in game pack selector, you can use this [tutorial](https://jamesturner.yt/disablepacks) by James Turner.
 - Open the Archipelago Launcher and run the client. It should be called `The Sims 4 Client`. Upon the first time opening the client, it will prompt you to select your Mods folder. <strong>ONLY SELECT THE MODS FOLDER LOCATED AT</strong> <code>(your sims folder, typically called The Sims 4)/Mods</code>.
+  * If you have to manually se the path make sure you dont include quotes in the path
 - Once you have selected the Mods folder if you've been prompted for it, follow the next steps before connecting.
 - Launch your copy of The Sims 4, and ensure you have Script Mods enabled. The mod will not work correctly if Script Mods are not enabled.
   * You can enable Script Mods by going to `Game Options -> Other -> Script Mods Allowed`.

--- a/worlds/sims4/docs/setup_en.md
+++ b/worlds/sims4/docs/setup_en.md
@@ -25,7 +25,7 @@
   * If you don't know how disable packs without using the in game pack selector, you can use this [tutorial](https://jamesturner.yt/disablepacks) by James Turner.
 - Open the Archipelago Launcher and run the client. It should be called `The Sims 4 Client`. Upon the first time opening the client, it will prompt you to select your Mods folder. <strong>ONLY SELECT THE MODS FOLDER LOCATED AT</strong> <code>(your sims folder, typically called The Sims 4)/Mods</code>.
   * If you have to manually set the path make sure you don't include quotes in the path.
-  * Example: <code>/set_path C:/Users/User/Documents/Electronic Arts/The Sims 4/Mods</code>
+  * Example (Windows): <code>/set_path C:/Users/User/Documents/Electronic Arts/The Sims 4/Mods</code>
 - Once you have selected the Mods folder if you've been prompted for it, follow the next steps before connecting.
 - Launch your copy of The Sims 4, and ensure you have Script Mods enabled. The mod will not work correctly if Script Mods are not enabled.
   * You can enable Script Mods by going to `Game Options -> Other -> Script Mods Allowed`.

--- a/worlds/sims4/docs/setup_en.md
+++ b/worlds/sims4/docs/setup_en.md
@@ -24,7 +24,7 @@
 - By default, this mod only uses skills from the base game as checks and locations. You can optionally enable your packs in the YAML file if you would like to have them included in the randomization. Packs are unlikely to cause problems with the mod, however you can disable them optionally **NOT USING THE IN GAME PACK SELECTOR**.
   * If you don't know how disable packs without using the in game pack selector, you can use this [tutorial](https://jamesturner.yt/disablepacks) by James Turner.
 - Open the Archipelago Launcher and run the client. It should be called `The Sims 4 Client`. Upon the first time opening the client, it will prompt you to select your Mods folder. <strong>ONLY SELECT THE MODS FOLDER LOCATED AT</strong> <code>(your sims folder, typically called The Sims 4)/Mods</code>.
-  * If you have to manually set the path make sure you dont include quotes in the path
+  * If you have to manually set the path make sure you don't include quotes in the path.
   * Example: <code>/set_path C:/Users/User/Documents/Electronic Arts/The Sims 4/Mods</code>
 - Once you have selected the Mods folder if you've been prompted for it, follow the next steps before connecting.
 - Launch your copy of The Sims 4, and ensure you have Script Mods enabled. The mod will not work correctly if Script Mods are not enabled.


### PR DESCRIPTION
Just added an example for the set_path command 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified manual path setup: instruct users not to surround paths with quotation marks and added a concrete example Windows path to follow.
  * Clarified save-file guidance for scripted runs: noted that an existing save can be reused but recommend creating a new save per run and warned about potential issues when reusing the same save across multiple runs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->