### PR TITLE
Add an additional check that /set_path was given an absolute file path

### DIFF
--- a/worlds/sims4/Client.py
+++ b/worlds/sims4/Client.py
@@ -92,11 +92,13 @@ class SimsCommandProcessor(ClientCommandProcessor):
         """Set the file path to the Sims 4 mods folder manually (if automatic detection fails)"""
         p = sims_4_mods_path
         global mod_data_path
-        if p == '':
-            self.output('no path inputed')
+        if not p:
+            self.output("no path inputed")
         elif os.path.exists(os.path.join(p, 'mod_data', 's4ap')):
             self.output('Sims 4 mods folder found')
             mod_data_path = os.path.join(p, 'mod_data', 's4ap')
+        elif not os.path.isabs(p):
+            self.output("Please enter the full path to the Sims 4 mods folder.\nFor example: C:\\Users\\Username\\Documents\\Electronic Arts\\The Sims 4\\Mods")
         else:
             self.ctx.gui_error(title='Sims 4 mods folder not found',
                                text=f'Make sure the file path you inputed is correct.')

--- a/worlds/sims4/Client.py
+++ b/worlds/sims4/Client.py
@@ -252,7 +252,7 @@ async def game_watcher(ctx: SimsContext):
         await asyncio.sleep(0.5)
 
 
-def main(args):
+def main(args: list[str] | None = None) -> None:
     async def _main():
         parser = get_base_parser(description="The Sims 4 Client, for text interfacing.")
         _args, _rest = parser.parse_known_args(args)

--- a/worlds/sims4/Client.py
+++ b/worlds/sims4/Client.py
@@ -93,7 +93,7 @@ class SimsCommandProcessor(ClientCommandProcessor):
         p = sims_4_mods_path
         global mod_data_path
         if not p:
-            self.output("no path inputed")
+            self.output("No path provided")
         elif os.path.exists(os.path.join(p, 'mod_data', 's4ap')):
             self.output('Sims 4 mods folder found')
             mod_data_path = os.path.join(p, 'mod_data', 's4ap')


### PR DESCRIPTION
In-client feedback that the user didn't provide the expected input for the command.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved path validation with clearer error messages when no path is provided.
  * Added user-facing guidance prompting for full (absolute) paths and examples to reduce input errors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->